### PR TITLE
updated cache file format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: madrat
 Type: Package
 Title: May All Data be Reproducible and Transparent (MADRaT) *
-Version: 1.69.0
-Date: 2020-03-10
+Version: 1.70.0
+Date: 2020-03-16
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("Lavinia", "Baumstark", email = "lavinia@pik-potsdam.de", role = "aut"),
              person("Stephen", "Wirth", email = "wirth@pik-potsdam.de", role = "aut"),
@@ -38,4 +38,4 @@ LazyData: no
 Encoding: UTF-8
 RoxygenNote: 7.0.2
 VignetteBuilder: knitr
-ValidationKey: 30979390
+ValidationKey: 31172900

--- a/R/initializeConfig.R
+++ b/R/initializeConfig.R
@@ -13,23 +13,24 @@ initializeConfig <- function(verbose=TRUE) {
   if(is.null(getOption("madrat_cfg"))) {
     if(verbose) base::cat("\nInitialize madrat config with default settings..\n")
     
-    cfg <- list(regionmapping = "regionmappingH12.csv",
-                packages      = "madrat",
-                globalenv     = FALSE,
-                verbosity     = 1,
-                enablecache   = TRUE,
-                mainfolder    = getMainfolder(verbose=verbose),
-                sourcefolder  = NA,
-                cachefolder   = NA,
-                mappingfolder = NA,
-                outputfolder  = NA,
-                pop_threshold = 10^6,
-                forcecache    = FALSE,
-                ignorecache   = NULL,
-                delete_cache  = TRUE,
-                diagnostics   = FALSE,
-                nocores       = 1,
-                debug         = FALSE)
+    cfg <- list(regionmapping    = "regionmappingH12.csv",
+                packages         = "madrat",
+                globalenv        = FALSE,
+                verbosity        = 1,
+                enablecache      = TRUE,
+                mainfolder       = getMainfolder(verbose=verbose),
+                sourcefolder     = NA,
+                cachefolder      = NA,
+                mappingfolder    = NA,
+                outputfolder     = NA,
+                pop_threshold    = 10^6,
+                forcecache       = FALSE,
+                ignorecache      = NULL,
+                cachecompression = "xz",
+                delete_cache     = TRUE,
+                diagnostics      = FALSE,
+                nocores          = 1,
+                debug            = FALSE)
      options(madrat_cfg = cfg)
      if(verbose) {
       base::cat(paste(paste0("    ",names(cfg)),cfg,sep=" = ",collapse="\n"))

--- a/R/setConfig.R
+++ b/R/setConfig.R
@@ -46,6 +46,9 @@
 #'  given vector of files (e.g. readTau, calcTauTotal) or types 
 #'  (e.g. Tau, TauTotal) called by calcOutput or readSource.
 #'  The top level function must always be part of this list.
+#' @param cachecompression logical or character string specifying whether cache files
+#' use compression. TRUE corresponds to gzip compression, and character strings "gzip", 
+#' "bzip2" or "xz" specify the type of compression.
 #' @param delete_cache Boolean deciding whether a temporary cache folder (as
 #' created by retrieveInput) should be deleted after completion or not.
 #' @param diagnostics file name for additional diagnostics information (without file ending).
@@ -85,6 +88,7 @@ setConfig <- function(regionmapping=NULL,
                       pop_threshold=NULL,
                       forcecache=NULL,
                       ignorecache = NULL,
+                      cachecompression=NULL,
                       delete_cache=NULL,
                       diagnostics=NULL,
                       nocores=NULL,


### PR DESCRIPTION
- changed cachefile naming for calc files to prevent "too long file name" errors (a hash value is now used instead of the arguments itself). Old cache files still will be read in if the cache file in the new format is not found.

- changed from rda to rds format

- added option "cachecompression" to general settings to allow customization of cache compression